### PR TITLE
Fix PHP warnings in test viewer

### DIFF
--- a/app/code/community/Codex/Xtest/Model/Phpunit/Listener.php
+++ b/app/code/community/Codex/Xtest/Model/Phpunit/Listener.php
@@ -103,7 +103,7 @@ class Codex_Xtest_Model_Phpunit_Listener implements PHPUnit_Framework_TestListen
         $result = array(
             'testName' => $testName,
             'time' => $time,
-            'exception' => $this->lastResult,
+            'exception' => (string) $this->lastResult,
             'status' => $this->lastStatus,
             'description' => $this->getDocComment($test),
             'screenshots' => array()

--- a/tests/view/index.php
+++ b/tests/view/index.php
@@ -118,7 +118,7 @@ require __DIR__ . '/lib.php';
                             onclick="jQuery(this).parent().children('ul').toggle(); ">
                             <?php echo $suiteName; ?>
 
-                            <?php foreach ($testClass->tags AS $tag) : ?>
+                            <?php if (isset($testClass->tags)) foreach ($testClass->tags AS $tag) : ?>
 
                                 <span class="badge badge-default">
                                         <?php echo $tag; ?>
@@ -143,7 +143,7 @@ require __DIR__ . '/lib.php';
                                             <?php echo $_test->testName; ?>
 
 
-                                            <?php foreach ($_test->tags AS $tag) : ?>
+                                            <?php if (isset($_test->tags)) foreach ($_test->tags AS $tag) : ?>
 
                                                 <span class="badge badge-default">
                                                         @<?php echo $tag; ?>


### PR DESCRIPTION
Related to the problem described in issue #8

- log exceptions as string
- "tags" seem not to be used but to not break any additional implementations that rely on them, I opted for an `isset()` check.