### PR TITLE
Make test classes abstract that should not be instantiated

### DIFF
--- a/app/code/community/Codex/Xtest/Xtest/Unit/Abstract.php
+++ b/app/code/community/Codex/Xtest/Xtest/Unit/Abstract.php
@@ -1,6 +1,6 @@
 <?php
 
-class Codex_Xtest_Xtest_Unit_Abstract extends PHPUnit_Framework_TestCase
+abstract class Codex_Xtest_Xtest_Unit_Abstract extends PHPUnit_Framework_TestCase
 {
     const METHOD_GET = 'GET';
     const METHOD_POST = 'POST';

--- a/app/code/community/Codex/Xtest/Xtest/Unit/Admin.php
+++ b/app/code/community/Codex/Xtest/Xtest/Unit/Admin.php
@@ -1,6 +1,6 @@
 <?php
 
-class Codex_Xtest_Xtest_Unit_Admin extends Codex_Xtest_Xtest_Unit_Abstract
+abstract class Codex_Xtest_Xtest_Unit_Admin extends Codex_Xtest_Xtest_Unit_Abstract
 {
     protected function setUp()
     {

--- a/app/code/community/Codex/Xtest/Xtest/Unit/Frontend.php
+++ b/app/code/community/Codex/Xtest/Xtest/Unit/Frontend.php
@@ -1,6 +1,6 @@
 <?php
 
-class Codex_Xtest_Xtest_Unit_Frontend extends Codex_Xtest_Xtest_Unit_Abstract
+abstract class Codex_Xtest_Xtest_Unit_Frontend extends Codex_Xtest_Xtest_Unit_Abstract
 {
     protected function setUp()
     {


### PR DESCRIPTION
Otherwise PHPUnit complains about test cases without tests